### PR TITLE
Update hostnames to magento2.local

### DIFF
--- a/deploy/bases/app/ingress/main.yaml
+++ b/deploy/bases/app/ingress/main.yaml
@@ -16,7 +16,7 @@ spec:
       port:
         name: http
   rules:
-    - host: mok.localhost
+    - host: magento2.local
       http:
         paths:
           - path: /

--- a/overlays/kind/kustomization.yaml
+++ b/overlays/kind/kustomization.yaml
@@ -9,3 +9,11 @@ configMapGenerator:
   behavior: merge
   envs:
   - patches/common.env
+
+patchesJson6902:
+- path: patches/ingress.json
+  target:
+    group: networking.k8s.io
+    version: v1
+    kind: Ingress
+    name: main

--- a/overlays/kind/patches/ingress.json
+++ b/overlays/kind/patches/ingress.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/spec/rules/0/host",
+    "value": "mok.localhost"
+  }
+]


### PR DESCRIPTION
At the moment there are two hostnames used around the project; this PR changes all, apart from Kind, uses to magento2.local